### PR TITLE
Added new option to insert new keys if they don’t exist

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -24,16 +24,23 @@ if [ -z "${plist_value}" ] ; then
   exit 1
 fi
 
+if [ -z "${plist_add_missing_keys}" ] ; then
+  echo " [!] Missing required input: plist_add_missing_keys (true or false)!"
+  exit 1
+fi
+
 # ---------------------
 # --- Configs:
 
 CONFIG_project_info_plist_path="${plist_path}"
 CONFIG_plist_key_string="${plist_key}"
 CONFIG_plist_value_string="${plist_value}"
+CONFIG_plist_add_missing_keys="${plist_add_missing_keys}"
 
 echo " (i) Provided Info.plist path: ${CONFIG_project_info_plist_path}"
 echo " (i) Plist Key: ${CONFIG_plist_key_string}"
 echo " (i) Plist value: ${CONFIG_plist_value_string}"
+echo " (i) Add missing keys: ${CONFIG_plist_add_missing_keys}"
 
 # ---------------------
 # --- Main:
@@ -42,5 +49,9 @@ echo " (i) Plist value: ${CONFIG_plist_value_string}"
 set -v
 
 # ---- Change Plist Value:
-/usr/libexec/PlistBuddy -c "Set :${CONFIG_plist_key_string} ${CONFIG_plist_value_string}" "${CONFIG_project_info_plist_path}"
+if [[ "${CONFIG_plist_add_missing_keys}" == "true" ]] ; then
+  /usr/libexec/PlistBuddy -c "Add :${CONFIG_plist_key_string} string ${CONFIG_plist_value_string}" "${CONFIG_project_info_plist_path}"
+else
+  /usr/libexec/PlistBuddy -c "Set :${CONFIG_plist_key_string} ${CONFIG_plist_value_string}" "${CONFIG_project_info_plist_path}"
+fi
 # ==> Plist value changed

--- a/step.yml
+++ b/step.yml
@@ -38,3 +38,14 @@ inputs:
       description: |
         The value of the key in the plist file you wish to set.
       is_required: true
+  - plist_add_missing_keys: "false"
+    opts:
+      title: Add missing keys?
+      description: |-
+        (Optional) Will insert the value of the provided key if it isn't already present in the plist file.
+        Options:
+        * "true"
+        * "false"
+      is_expand: false
+      value_options: ["true", "false"]
+      is_dont_change_value: true


### PR DESCRIPTION
I have a requirement to insert a key into my Info.plist file at build time (a token used by a crash reporting service) and my code checks for the presence of this value at runtime.

I found it annoying that in order to set the value of a plist key it needs to already exist. PlistBuddy can happily insert new keys, so this adds an option to do just that.

Most people probably just need to change an existing value. If you enable this and are trying to update an existing value then any typo in the key name will not cause an error so I've left it off by default.